### PR TITLE
Fix tests to account for Composite Discovery Client

### DIFF
--- a/configserver-eureka/src/test/java/demo/ConfigServerEurekaApplicationTests.java
+++ b/configserver-eureka/src/test/java/demo/ConfigServerEurekaApplicationTests.java
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClient;
 import org.springframework.cloud.netflix.eureka.EurekaDiscoveryClient;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -25,7 +26,9 @@ public class ConfigServerEurekaApplicationTests {
 
 	@Test
 	public void discoveryClientIsEureka() {
-		assertTrue("discoveryClient is wrong type", discoveryClient instanceof EurekaDiscoveryClient);
+		assertTrue("discoveryClient is wrong type", discoveryClient instanceof CompositeDiscoveryClient);
+		assertTrue("composite discovery client should have a Eureka client with higher precendence"
+				, ((CompositeDiscoveryClient)discoveryClient).getDiscoveryClients().get(0) instanceof EurekaDiscoveryClient);
 	}
 
 }

--- a/eureka-first/src/test/java/demo/EurekaFirstApplicationTests.java
+++ b/eureka-first/src/test/java/demo/EurekaFirstApplicationTests.java
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClient;
 import org.springframework.cloud.netflix.eureka.EurekaDiscoveryClient;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -25,7 +26,10 @@ public class EurekaFirstApplicationTests {
 
 	@Test
 	public void discoveryClientIsEureka() {
-		assertTrue("discoveryClient is wrong type: " + discoveryClient, discoveryClient instanceof EurekaDiscoveryClient);
+		assertTrue("discoveryClient is wrong type: " + discoveryClient, 
+				discoveryClient instanceof CompositeDiscoveryClient);
+		assertTrue("composite discovery client should have a Eureka client with higher precendence"
+				, ((CompositeDiscoveryClient)discoveryClient).getDiscoveryClients().get(0) instanceof EurekaDiscoveryClient);
 	}
 
 }

--- a/eureka-noweb/src/test/java/demo/DefaultStandaloneClientApplicationTests.java
+++ b/eureka-noweb/src/test/java/demo/DefaultStandaloneClientApplicationTests.java
@@ -5,7 +5,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
-import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClient;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClient;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -22,7 +22,7 @@ public class DefaultStandaloneClientApplicationTests {
 	@Test
 	public void testDiscoveryClientIsSimple() {
 		assertTrue("discoveryClient is wrong instance type",
-				discoveryClient instanceof SimpleDiscoveryClient);
+				discoveryClient instanceof CompositeDiscoveryClient);
 	}
 
 }

--- a/eureka-noweb/src/test/java/demo/StandaloneClientApplicationTests.java
+++ b/eureka-noweb/src/test/java/demo/StandaloneClientApplicationTests.java
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClient;
 import org.springframework.cloud.netflix.eureka.EurekaDiscoveryClient;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -21,7 +22,9 @@ public class StandaloneClientApplicationTests {
 
 	@Test
 	public void testDiscoveryClientIsEureka() {
-		assertTrue("discoveryClient is wrong instance type", discoveryClient instanceof EurekaDiscoveryClient);
+		assertTrue("discoveryClient is wrong instance type", discoveryClient instanceof CompositeDiscoveryClient);
+		assertTrue("composite discovery client should have a Eureka client with higher precendence"
+				, ((CompositeDiscoveryClient)discoveryClient).getDiscoveryClients().get(0) instanceof EurekaDiscoveryClient);
 	}
 
 }

--- a/eureka-server/src/test/java/demo/EurekaServerApplicationTests.java
+++ b/eureka-server/src/test/java/demo/EurekaServerApplicationTests.java
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClient;
 import org.springframework.cloud.netflix.eureka.EurekaDiscoveryClient;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -25,7 +26,14 @@ public class EurekaServerApplicationTests {
 
 	@Test
 	public void discoveryClientIsEureka() {
-		assertTrue("discoveryClient is wrong type: " + this.discoveryClient, this.discoveryClient instanceof EurekaDiscoveryClient);
+		assertTrue("discoveryClient is wrong type " + discoveryClient.getClass(), discoveryClient instanceof CompositeDiscoveryClient);
+		CompositeDiscoveryClient compositeDiscoveryClient = (CompositeDiscoveryClient) discoveryClient;
+		assertTrue("composite discovery client should be composed of Eureka and Simple Discovery client's"
+				, compositeDiscoveryClient.getDiscoveryClients().size() == 2);
+
+		assertTrue("the composed discovery client should have a EurekaDiscoveryClient with a higher precedence ",
+				compositeDiscoveryClient.getDiscoveryClients().get(0) instanceof EurekaDiscoveryClient);
 	}
+
 
 }

--- a/feign-eureka/src/test/java/demo/NoWebApplicationTests.java
+++ b/feign-eureka/src/test/java/demo/NoWebApplicationTests.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
-import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClient;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClient;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -23,7 +23,7 @@ public class NoWebApplicationTests {
 	@Test
 	public void testDiscoveryClientIsSimple() {
 		assertTrue("discoveryClient is wrong instance type",
-				discoveryClient instanceof SimpleDiscoveryClient);
+				discoveryClient instanceof CompositeDiscoveryClient);
 	}
 
 }

--- a/noweb/src/test/java/test/DiscoveryNotWebApplicationTests.java
+++ b/noweb/src/test/java/test/DiscoveryNotWebApplicationTests.java
@@ -11,7 +11,7 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
-import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClient;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClient;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.junit.Assert.assertTrue;
@@ -28,7 +28,7 @@ public class DiscoveryNotWebApplicationTests {
 	@Test
 	public void testDiscoveryClientIsSimple() {
 		assertTrue("discoveryClient is wrong instance type",
-				discoveryClient instanceof SimpleDiscoveryClient);
+				discoveryClient instanceof CompositeDiscoveryClient);
 	}
 
 	/*

--- a/turbine-amqp/src/test/java/demo/TurbineStreamApplicationTests.java
+++ b/turbine-amqp/src/test/java/demo/TurbineStreamApplicationTests.java
@@ -7,6 +7,8 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClient;
+import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClient;
 import org.springframework.cloud.netflix.eureka.EurekaDiscoveryClient;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -25,7 +27,16 @@ public class TurbineStreamApplicationTests {
 
 	@Test
 	public void discoveryClientIsEureka() {
-		assertTrue("discoveryClient is wrong type " + discoveryClient.getClass(), discoveryClient instanceof EurekaDiscoveryClient);
+		assertTrue("discoveryClient is wrong type " + discoveryClient.getClass(), discoveryClient instanceof CompositeDiscoveryClient);
+		CompositeDiscoveryClient compositeDiscoveryClient = (CompositeDiscoveryClient)discoveryClient;
+		assertTrue("composite discovery client should be composed of Eureka and Simple Discovery client's"
+				, compositeDiscoveryClient.getDiscoveryClients().size() == 2);
+
+		assertTrue("the composed discovery client should have a EurekaDiscoveryClient with a higher precedence ",
+				compositeDiscoveryClient.getDiscoveryClients().get(0) instanceof EurekaDiscoveryClient);
+
+		assertTrue("the composed discovery client should have a SimpleDiscoveryClient with a lower precedence ",
+				compositeDiscoveryClient.getDiscoveryClients().get(1) instanceof SimpleDiscoveryClient);
 	}
 	
 }

--- a/turbine/src/test/java/demo/TurbineApplicationTests.java
+++ b/turbine/src/test/java/demo/TurbineApplicationTests.java
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
-import org.springframework.cloud.netflix.eureka.EurekaDiscoveryClient;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClient;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -25,7 +25,7 @@ public class TurbineApplicationTests {
 
 	@Test
 	public void discoveryClientIsEureka() {
-		assertTrue("discoveryClient is wrong type", discoveryClient instanceof EurekaDiscoveryClient);
+		assertTrue("discoveryClient is wrong type", discoveryClient instanceof CompositeDiscoveryClient);
 	}
 	
 }

--- a/zuul-proxy-eureka/src/test/java/demo/ZuulProxyEurekaApplicationTests.java
+++ b/zuul-proxy-eureka/src/test/java/demo/ZuulProxyEurekaApplicationTests.java
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClient;
 import org.springframework.cloud.netflix.eureka.EurekaDiscoveryClient;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -25,7 +26,9 @@ public class ZuulProxyEurekaApplicationTests {
 
 	@Test
 	public void discoveryClientIsEureka() {
-		assertTrue("discoveryClient is wrong type", discoveryClient instanceof EurekaDiscoveryClient);
+		assertTrue("discoveryClient is wrong type", discoveryClient instanceof CompositeDiscoveryClient);
+		assertTrue("composite discovery client should compose Eureka Discovery Client with highest precedence", 
+				((CompositeDiscoveryClient)discoveryClient).getDiscoveryClients().get(0) instanceof EurekaDiscoveryClient);
 	}
 
 }

--- a/zuul-proxy/src/test/java/demo/ZuulProxyApplicationTests.java
+++ b/zuul-proxy/src/test/java/demo/ZuulProxyApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
-import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClient;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClient;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
@@ -51,7 +51,7 @@ public class ZuulProxyApplicationTests {
 	}
 
 	@Test
-	public void discoveryClientIsSimple() {
-		assertTrue("discoveryClient is wrong type", this.discoveryClient instanceof SimpleDiscoveryClient);
+	public void discoveryClientIsComposite() {
+		assertTrue("discoveryClient is wrong type", this.discoveryClient instanceof CompositeDiscoveryClient);
 	}
 }

--- a/zuul/src/test/java/demo/ZuulApplicationTests.java
+++ b/zuul/src/test/java/demo/ZuulApplicationTests.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
-import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClient;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClient;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -33,8 +33,8 @@ public class ZuulApplicationTests {
 	}
 
 	@Test
-	public void discoveryClientIsSimple() {
+	public void discoveryClientIsComposite() {
 		assertTrue("discoveryClient is wrong type",
-				this.discoveryClient instanceof SimpleDiscoveryClient);
+				this.discoveryClient instanceof CompositeDiscoveryClient);
 	}
 }


### PR DESCRIPTION
This fixes the tests which broke because of the introduction of CompositeDiscoveryClient

//cc @ryanjbaxter @spencergibb 