### PR TITLE
URL Cleanup

### DIFF
--- a/feign-eager-instantiation/src/main/java/demo/ExampleClient.java
+++ b/feign-eager-instantiation/src/main/java/demo/ExampleClient.java
@@ -4,7 +4,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-@FeignClient(name = "example", url = "http://example.com")
+@FeignClient(name = "example", url = "https://example.com")
 public interface ExampleClient {
 
     @RequestMapping(value = "/", method = RequestMethod.GET)

--- a/hystrix/README.md
+++ b/hystrix/README.md
@@ -1,6 +1,6 @@
 # About
 This project is a sample of using just the Hystrix Starter.  For more information see the
-[Hystrix documentation](http://cloud.spring.io/spring-cloud-static/spring-cloud.html#_circuit_breaker_hystrix_clients).
+[Hystrix documentation](https://cloud.spring.io/spring-cloud-static/spring-cloud.html#_circuit_breaker_hystrix_clients).
 
 # Usage
 This simple app contains two endpoints both surrounded by Hystrix circuit breakers.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-static/spring-cloud.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-static/spring-cloud.html ([https](https://cloud.spring.io/spring-cloud-static/spring-cloud.html) result 200).
* [ ] http://example.com with 1 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).

# Ignored
These URLs were intentionally ignored.

* http://foo/bar with 1 occurrences
* http://localhost with 17 occurrences
* http://localhost:7777 with 1 occurrences
* http://localhost:8000/src/main/resources/health.json with 1 occurrences
* http://localhost:8080 with 1 occurrences
* http://localhost:8080/hystrix.stream with 1 occurrences
* http://localhost:8888 with 1 occurrences
* http://nosuchservice with 1 occurrences
* http://simple/ with 1 occurrences
* http://user with 2 occurrences
* http://user::password@localhost:8761/eureka/ with 1 occurrences